### PR TITLE
Use executable so `swift run swifty-poeditor` is possible

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,9 @@ let package = Package(
     platforms: [
         .macOS(.v10_14)
     ],
+    products: [
+        .executable(name: "swifty-poeditor", targets: ["swifty-poeditor"]),
+    ],
     dependencies: [
         .package(url: "https://github.com/yanagiba/swift-ast.git",
                  from: "0.19.9"),

--- a/Sources/swifty-poeditor/main.swift
+++ b/Sources/swifty-poeditor/main.swift
@@ -5,14 +5,13 @@ let console: Console = Terminal()
 var input = CommandInput(arguments: CommandLine.arguments)
 
 // creating of CLI command handlers and binding them to CLI
-var config = CommandConfiguration()
+var config = Commands()
 config.use(UploadCommand(), as: "upload", isDefault: true)
 config.use(DownloadCommand(), as: "download")
 
 do {
     // start CLI commands handler
-    let commands = try config.resolve()
-        .group(help: "SwiftyPoeditor - command line tool to sync local translations with remote on POEditor service")
+    let commands = config.group(help: "SwiftyPoeditor - command line tool to sync local translations with remote on POEditor service")
     try console.run(commands, input: input)
 } catch {
     console.error("Error: \(error.localizedDescription)")


### PR DESCRIPTION
In order to make `swift run swifty-poeditor` possible, I've added the executable product.